### PR TITLE
custom fonts with only a few glyphs wont validate

### DIFF
--- a/Swicon/Swicon/Swicon.swift
+++ b/Swicon/Swicon/Swicon.swift
@@ -214,7 +214,7 @@ private func loadFontFromFile(fontFileName: String, forClass: AnyClass, isCustom
         let provider = CGDataProviderCreateWithCFData(data)
         let font = CGFontCreateWithDataProvider(provider)!
         
-        if (!CTFontManagerRegisterGraphicsFont(font, nil)) {
+        if (!CTFontManagerRegisterGraphicsFont(font, nil) && isCustom == false) {
             NSLog("Failed to load font \(fontFileName)");
             return false
         } else {


### PR DESCRIPTION
this may not be an ideal fix, but the the font works fine even though it does not pass CTFontManagerRegisterGraphicsFont validation... skipping the test for custom fonts works around the issue.
